### PR TITLE
Support FluentAssertions 6

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,4 +9,6 @@ This release also:
 
 - Upgrades xUnit to 2.4.1 and xUnit VS runner to 2.4.3
 - Upgrades Serilog to 2.10.0
-- Formats the `LogEventLevel` values so that they are always presented in assertion messages as `"Information"`. This is to ensure the assertions show consistent behaviour when using FluentAssertions 5 or 6.
+- Formats the `LogEventLevel` values so that they are always presented in assertion messages as `"Information"`. This is to ensure the assertions show consistent behaviour when using FluentAssertions 5 or 6
+- Adds netcoreapp3.1 as a test target
+- Removes netcoreapp2.0 as a test target as it's no longer supported

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## Serilog.Sinks.InMemory.Assertions: 0.9.0
+
+This release introduces support for FluentAssertions 6.x and maintains backwards compatibility with FluentAssertions 5.x releases.
+A test project has been added to verify this compatibility, see Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6
+
+This release also:
+
+- Upgrades xUnit to 2.4.1 and xUnit VS runner to 2.4.3
+- Upgrades Serilog to 2.10.0
+- Formats the `LogEventLevel` values so that they are always presented in assertion messages as `"Information"`. This is to ensure the assertions show consistent behaviour when using FluentAssertions 5 or 6.

--- a/SerilogSinksInMemory.sln
+++ b/SerilogSinksInMemory.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31702.278
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{B73801C2-972F-48CD-A47A-87A4544953E2}"
 EndProject
@@ -19,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6", "test\Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6\Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6.csproj", "{F65ECEEE-4461-48EE-98BE-003BBC716FC5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -78,6 +80,18 @@ Global
 		{B2B802A5-04A4-4844-8A3E-CCEC78101C1C}.Release|x64.Build.0 = Release|Any CPU
 		{B2B802A5-04A4-4844-8A3E-CCEC78101C1C}.Release|x86.ActiveCfg = Release|Any CPU
 		{B2B802A5-04A4-4844-8A3E-CCEC78101C1C}.Release|x86.Build.0 = Release|Any CPU
+		{F65ECEEE-4461-48EE-98BE-003BBC716FC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F65ECEEE-4461-48EE-98BE-003BBC716FC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F65ECEEE-4461-48EE-98BE-003BBC716FC5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F65ECEEE-4461-48EE-98BE-003BBC716FC5}.Debug|x64.Build.0 = Debug|Any CPU
+		{F65ECEEE-4461-48EE-98BE-003BBC716FC5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F65ECEEE-4461-48EE-98BE-003BBC716FC5}.Debug|x86.Build.0 = Debug|Any CPU
+		{F65ECEEE-4461-48EE-98BE-003BBC716FC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F65ECEEE-4461-48EE-98BE-003BBC716FC5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F65ECEEE-4461-48EE-98BE-003BBC716FC5}.Release|x64.ActiveCfg = Release|Any CPU
+		{F65ECEEE-4461-48EE-98BE-003BBC716FC5}.Release|x64.Build.0 = Release|Any CPU
+		{F65ECEEE-4461-48EE-98BE-003BBC716FC5}.Release|x86.ActiveCfg = Release|Any CPU
+		{F65ECEEE-4461-48EE-98BE-003BBC716FC5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -87,6 +101,7 @@ Global
 		{32BA2907-C3CD-4957-88EE-C64FA6CFC7E3} = {056C07B9-CAD5-4F92-8A24-FBDFDCBA0DDD}
 		{57388B94-C61A-48CA-B7B7-9E82233DB7ED} = {B73801C2-972F-48CD-A47A-87A4544953E2}
 		{B2B802A5-04A4-4844-8A3E-CCEC78101C1C} = {056C07B9-CAD5-4F92-8A24-FBDFDCBA0DDD}
+		{F65ECEEE-4461-48EE-98BE-003BBC716FC5} = {056C07B9-CAD5-4F92-8A24-FBDFDCBA0DDD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7573ED42-AA91-4C5A-8355-F60D23EC57B1}

--- a/src/Serilog.Sinks.InMemory.Assertions/InMemorySinkAssertions.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions/InMemorySinkAssertions.cs
@@ -10,9 +10,8 @@ namespace Serilog.Sinks.InMemory.Assertions
 {
     public class InMemorySinkAssertions : ReferenceTypeAssertions<InMemorySink, InMemorySinkAssertions>
     {
-        public InMemorySinkAssertions(InMemorySink instance)
+        public InMemorySinkAssertions(InMemorySink instance) : base(SnapshotOf(instance))
         {
-            Subject = SnapshotOf(instance);
         }
         
         /*

--- a/src/Serilog.Sinks.InMemory.Assertions/LogEventAssertion.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions/LogEventAssertion.cs
@@ -37,8 +37,8 @@ namespace Serilog.Sinks.InMemory.Assertions
                 .ForCondition(Subject.Level == level)
                 .FailWith("Expected message {0} to have level {1}, but it is {2}",
                     _messageTemplate,
-                    level,
-                    Subject.Level);
+                    level.ToString(),
+                    Subject.Level.ToString());
 
             return this;
         }

--- a/src/Serilog.Sinks.InMemory.Assertions/LogEventAssertion.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions/LogEventAssertion.cs
@@ -8,10 +8,9 @@ namespace Serilog.Sinks.InMemory.Assertions
     {
         private readonly string _messageTemplate;
 
-        public LogEventAssertion(string messageTemplate, LogEvent subject)
+        public LogEventAssertion(string messageTemplate, LogEvent subject) : base(subject)
         {
             _messageTemplate = messageTemplate;
-            Subject = subject;
         }
 
         protected override string Identifier => "log event";

--- a/src/Serilog.Sinks.InMemory.Assertions/LogEventPropertyValueAssertions.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions/LogEventPropertyValueAssertions.cs
@@ -11,9 +11,9 @@ namespace Serilog.Sinks.InMemory.Assertions
         private readonly LogEventAssertion _logEventAssertion;
 
         public LogEventPropertyValueAssertions(LogEventAssertion logEventAssertion, LogEventPropertyValue instance, string propertyName)
+            : base(instance)
         {
             _logEventAssertion = logEventAssertion;
-            Subject = instance;
             Identifier = propertyName;
         }
 

--- a/src/Serilog.Sinks.InMemory.Assertions/LogEventsAssertions.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions/LogEventsAssertions.cs
@@ -10,10 +10,9 @@ namespace Serilog.Sinks.InMemory.Assertions
     {
         private readonly string _messageTemplate;
 
-        public LogEventsAssertions(string messageTemplate, IEnumerable<LogEvent> matches)
+        public LogEventsAssertions(string messageTemplate, IEnumerable<LogEvent> matches) : base(matches)
         {
             _messageTemplate = messageTemplate;
-            Subject = matches;
         }
 
         protected override string Identifier { get; } = "log events";

--- a/src/Serilog.Sinks.InMemory.Assertions/LogEventsAssertions.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions/LogEventsAssertions.cs
@@ -61,7 +61,7 @@ namespace Serilog.Sinks.InMemory.Assertions
                 notMatched
                 .GroupBy(logEvent => logEvent.Level,
                 logEvent => logEvent,
-                (key, values) => $"{values.Count()} with level {key}"));
+                (key, values) => $"{values.Count()} with level \"{key}\""));
             }
 
             Execute.Assertion
@@ -69,7 +69,7 @@ namespace Serilog.Sinks.InMemory.Assertions
                 .ForCondition(Subject.All(logEvent => logEvent.Level == level))
                 .FailWith($"Expected instances of log message {{0}} to have level {{1}}, but found {notMatchedText}",
                     _messageTemplate,
-                    level);
+                    level.ToString());
 
             return this;
         }

--- a/src/Serilog.Sinks.InMemory.Assertions/LogEventsPropertyAssertion.cs
+++ b/src/Serilog.Sinks.InMemory.Assertions/LogEventsPropertyAssertion.cs
@@ -13,6 +13,7 @@ namespace Serilog.Sinks.InMemory.Assertions
         private readonly IEnumerable<LogEvent> _logEvents;
 
         public LogEventsPropertyAssertion(LogEventsAssertions logEventsAssertions, string propertyName)
+            : base(logEventsAssertions.Subject)
         {
             _logEventsAssertions = logEventsAssertions;
             _logEvents = logEventsAssertions.Subject;

--- a/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
+++ b/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
@@ -12,7 +12,7 @@
     <Copyright>2021 Sander van Vliet</Copyright>
     <Authors>Sander van Vliet</Authors>
     <PackageProjectUrl>https://github.com/sandermvanvliet/SerilogSinksInMemory/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/sandermvanvliet/SerilogSinksInMemory/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/sandermvanvliet/SerilogSinksInMemory/</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>

--- a/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
+++ b/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <Version>0.8.0</Version>
+    <Version>0.9.0</Version>
     <Title>Serilog in-memory sink assertion extensions</Title>
     <Description>FluentAssertions extensions to use with the Serilog.Sinks.InMemory package</Description>
     <Copyright>2021 Sander van Vliet</Copyright>

--- a/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
+++ b/src/Serilog.Sinks.InMemory.Assertions/Serilog.Sinks.InMemory.Assertions.csproj
@@ -22,7 +22,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.*" />
+    <PackageReference Include="FluentAssertions" Version="5.*">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Serilog.Sinks.InMemory" Version="0.*">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Serilog.Sinks.InMemory/Serilog.Sinks.InMemory.csproj
+++ b/src/Serilog.Sinks.InMemory/Serilog.Sinks.InMemory.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>images\icon.png</PackageIcon>
     <PackageIconUrl>https://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/sandermvanvliet/SerilogSinksInMemory/</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/sandermvanvliet/SerilogSinksInMemory/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/sandermvanvliet/SerilogSinksInMemory/</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6.csproj
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6.csproj
@@ -10,8 +10,11 @@
     <PackageReference Include="FluentAssertions" Version="6.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Serilog" Version="2.7.1" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6.csproj
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net462;netcoreapp2.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Serilog.Sinks.InMemory.Assertions\Serilog.Sinks.InMemory.Assertions.csproj" />
+    <ProjectReference Include="..\..\src\Serilog.Sinks.InMemory\Serilog.Sinks.InMemory.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Content Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\*.cs">
+    </Content>
+    <Compile Include="..\Serilog.Sinks.InMemory.Assertions.Tests.Unit\*.cs" />
+  </ItemGroup>
+
+</Project>

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6.csproj
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp2.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6.csproj
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6/Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/Serilog.Sinks.InMemory.Assertions.Tests.Unit.csproj
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/Serilog.Sinks.InMemory.Assertions.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/Serilog.Sinks.InMemory.Assertions.Tests.Unit.csproj
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/Serilog.Sinks.InMemory.Assertions.Tests.Unit.csproj
@@ -10,8 +10,11 @@
     <PackageReference Include="FluentAssertions" Version="5.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Serilog" Version="2.7.1" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/Serilog.Sinks.InMemory.Assertions.Tests.Unit.csproj
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/Serilog.Sinks.InMemory.Assertions.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp2.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/Serilog.Sinks.InMemory.Assertions.Tests.Unit.csproj
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/Serilog.Sinks.InMemory.Assertions.Tests.Unit.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/WhenAssertingLogEventHasLevel.cs
+++ b/test/Serilog.Sinks.InMemory.Assertions.Tests.Unit/WhenAssertingLogEventHasLevel.cs
@@ -32,7 +32,7 @@ namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
             action
                 .Should()
                 .Throw<XunitException>()
-                .WithMessage("Expected message \"Hello, world!\" to have level Warning, but it is Information");
+                .WithMessage("Expected message \"Hello, world!\" to have level \"Warning\", but it is \"Information\"");
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace Serilog.Sinks.InMemory.Assertions.Tests.Unit
             action
                 .Should()
                 .Throw<XunitException>()
-                .WithMessage("Expected instances of log message \"Hello, world!\" to have level Information, but found 3 with level Warning");
+                .WithMessage("Expected instances of log message \"Hello, world!\" to have level \"Information\", but found 3 with level \"Warning\"");
         }
     }
 }

--- a/test/Serilog.Sinks.InMemory.Tests.Unit/Serilog.Sinks.InMemory.Tests.Unit.csproj
+++ b/test/Serilog.Sinks.InMemory.Tests.Unit/Serilog.Sinks.InMemory.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Serilog.Sinks.InMemory.Tests.Unit/Serilog.Sinks.InMemory.Tests.Unit.csproj
+++ b/test/Serilog.Sinks.InMemory.Tests.Unit/Serilog.Sinks.InMemory.Tests.Unit.csproj
@@ -10,8 +10,11 @@
     <PackageReference Include="FluentAssertions" Version="5.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Serilog" Version="2.7.1" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Serilog.Sinks.InMemory.Tests.Unit/Serilog.Sinks.InMemory.Tests.Unit.csproj
+++ b/test/Serilog.Sinks.InMemory.Tests.Unit/Serilog.Sinks.InMemory.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;netcoreapp2.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/Serilog.Sinks.InMemory.Tests.Unit/Serilog.Sinks.InMemory.Tests.Unit.csproj
+++ b/test/Serilog.Sinks.InMemory.Tests.Unit/Serilog.Sinks.InMemory.Tests.Unit.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Serilog" Version="2.7.1" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This PR introduces support for FluentAssertions 6.x and maintains backwards compatibility with FluentAssertions 5.x releases.
A test project has been added to verify this compatibility, see Serilog.Sinks.InMemory.Assertions.Tests.Unit.FluentAssertions6

This PR also:

- Upgrades xUnit to 2.4.1 and xUnit VS runner to 2.4.3
- Upgrades Serilog to 2.10.0
- Formats the `LogEventLevel` values so that they are always presented in assertion messages as `"Information"`. This is to ensure the assertions show consistent behaviour when using FluentAssertions 5 or 6
- Adds netcoreapp3.1 as a test target
- Removes netcoreapp2.0 as a test target as it's no longer supported

With this pr #22 can be closed